### PR TITLE
Add a switch for Linux when opening directories as a workaround for x…

### DIFF
--- a/ChanThreadWatch.csproj
+++ b/ChanThreadWatch.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>JDP</RootNamespace>
     <AssemblyName>ChanThreadWatch</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ApplicationIcon>ChanThreadWatch.ico</ApplicationIcon>
     <SccProjectName>SAK</SccProjectName>

--- a/ChanThreadWatch.csproj
+++ b/ChanThreadWatch.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>JDP</RootNamespace>
     <AssemblyName>ChanThreadWatch</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ApplicationIcon>ChanThreadWatch.ico</ApplicationIcon>
     <SccProjectName>SAK</SccProjectName>
@@ -36,6 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup />
   <PropertyGroup>

--- a/frmChanThreadWatch.cs
+++ b/frmChanThreadWatch.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;

--- a/frmChanThreadWatch.cs
+++ b/frmChanThreadWatch.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
@@ -419,8 +420,12 @@ namespace JDP {
                             });
                         }
                         else {
-                            Process.Start(dir);
-                        }
+							if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+								Process.Start($"file://{Uri.EscapeUriString(dir)}"); // xdg-open fails on spaces
+							} else {
+								Process.Start(dir);
+							}
+						}
                     }
                     catch (Exception ex) {
                         Logger.Log(ex.ToString());

--- a/frmChanThreadWatch.cs
+++ b/frmChanThreadWatch.cs
@@ -420,12 +420,8 @@ namespace JDP {
                             });
                         }
                         else {
-							if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-								Process.Start($"file://{Uri.EscapeUriString(dir)}"); // xdg-open fails on spaces
-							} else {
-								Process.Start(dir);
-							}
-						}
+                            Process.Start(dir);
+                        }
                     }
                     catch (Exception ex) {
                         Logger.Log(ex.ToString());


### PR DESCRIPTION
On Linux systems xdg-open will normally try to find the best program to open directories with. It seems that with some later versions, there's issues if there's spaces in the file path.

![image](https://user-images.githubusercontent.com/8218786/48654428-95c94600-ea71-11e8-984e-4c57a41094ec.png)
Removing the space in the name is also a workaround on Linux
![image](https://user-images.githubusercontent.com/8218786/48654458-e80a6700-ea71-11e8-98d9-473567447c98.png)

Also for some reason the TargetFrameworkVersion inside the csproj was set at 2.0. Visual studio might have some way of handling that, but Jetbeans Rider and Mono do not.