### PR TITLE
Bug/20181120 semaphore full exception

### DIFF
--- a/Classes/Other.cs
+++ b/Classes/Other.cs
@@ -198,11 +198,12 @@ namespace JDP {
         public void Release() {
             lock (_mainSync) {
                 if (_currentCount >= _maximumCount) { // Workaround for Mono
-                    Type semaphoreException = Type.GetType("System.Threading.SemaphoreFullException");
-                    object instance = Activator.CreateInstance(semaphoreException);
-                    throw (SystemException)instance;
+
                 }
-                CheckQueue:
+                Type semaphoreException = Type.GetType("System.Threading.SemaphoreFullException");
+                object instance = Activator.CreateInstance(semaphoreException);
+                throw (SystemException)instance;
+            CheckQueue:
                 if (_queueSyncs.Count == 0) {
                     _currentCount++;
                 }

--- a/Classes/Other.cs
+++ b/Classes/Other.cs
@@ -198,12 +198,11 @@ namespace JDP {
         public void Release() {
             lock (_mainSync) {
                 if (_currentCount >= _maximumCount) { // Workaround for Mono
-
+                    Type semaphoreException = Type.GetType("System.Threading.SemaphoreFullException");
+                    object exception = Activator.CreateInstance(semaphoreException);
+                    throw (SystemException)exception;
                 }
-                Type semaphoreException = Type.GetType("System.Threading.SemaphoreFullException");
-                object instance = Activator.CreateInstance(semaphoreException);
-                throw (SystemException)instance;
-            CheckQueue:
+                CheckQueue:
                 if (_queueSyncs.Count == 0) {
                     _currentCount++;
                 }

--- a/Classes/Other.cs
+++ b/Classes/Other.cs
@@ -197,8 +197,10 @@ namespace JDP {
 
         public void Release() {
             lock (_mainSync) {
-                if (_currentCount >= _maximumCount) {
-                    throw new SemaphoreFullException();
+                if (_currentCount >= _maximumCount) { // Workaround for Mono
+                    Type semaphoreException = Type.GetType("System.Threading.SemaphoreFullException");
+                    object instance = Activator.CreateInstance(semaphoreException);
+                    throw (SystemException)instance;
                 }
                 CheckQueue:
                 if (_queueSyncs.Count == 0) {


### PR DESCRIPTION
What do you think on invoking the SemaphoreException via reflection as a workaround in Mono? Mono implements the exception, but it's just not finding it correctly due to missing redirects in the framework. This would only get called when there's an issue in the job queue, so the performance hit on using reflection would be negligible.

![image](https://user-images.githubusercontent.com/8218786/48761071-9f220f00-ed0c-11e8-94a6-e379b6bd590f.png)
