### PR TITLE
Bugfix: Move Threads on Remove Completed - Broken when category is set

### DIFF
--- a/frmChanThreadWatch.cs
+++ b/frmChanThreadWatch.cs
@@ -332,6 +332,9 @@ namespace JDP {
                                 if (Directory.Exists(destDir)) {
                                     Directory.Delete(destDir);
                                 }
+                                if (watcher.Category.Length != 0) {
+                                    Directory.CreateDirectory(General.RemoveLastDirectory(destDir));
+                                }
                                 Directory.Move(watcher.ThreadDownloadDirectory, destDir);
                             }
                             string categoryPath = General.RemoveLastDirectory(watcher.ThreadDownloadDirectory);


### PR DESCRIPTION
This PR fixes an issue which I've just run into-

**Problem**:
If you have moving completed threads enabled and have threads with categories set, upon removal, the threads will not be moved to the proper completed directory and will stay in the downloads\category directory.
<br>

This is due to the dotnet `Directory.Move` method; it expects all directories in the destination path to exist upon move, else it will fail to move the source file/dir.
My change adds three lines, it checks if the thread Category is not an empty string, and if so, creates the directory above the threads destination. The function is smart enough to know if the specified directory already exists and will more-or-less ignore the creation.

Built and tested the movement on my machine and it worked without issue. I don't believe this should introduce any other quirks since `thread.Category` is set to an empty string on the loading of a thread.